### PR TITLE
feat: support pattern model mapping

### DIFF
--- a/docs/Pattern-Models.md
+++ b/docs/Pattern-Models.md
@@ -1,0 +1,28 @@
+# Pattern Model Mapping
+
+Fabric can automatically select a model for a pattern based on a user-defined mapping file.
+
+## Configuration
+
+Create `~/.config/fabric/pattern_models.yaml` with entries mapping pattern names to models:
+
+```yaml
+summarize: openai/gpt-4o-mini
+ai: anthropic/claude-3-opus
+```
+
+The key is the pattern name. The value is the model identifier. If the value includes a vendor prefix (e.g. `openai/`), Fabric sets both the vendor and model accordingly.
+
+When you run a pattern without specifying `--model`, Fabric consults this file to determine the model to use.
+
+## Helper Command
+
+You can manage this mapping from the command line:
+
+```bash
+fabric pattern-model list
+fabric pattern-model set <pattern> <model>
+fabric pattern-model unset <pattern>
+```
+
+`set` updates the mapping file, creating it if necessary. `unset` removes a mapping. `list` shows all current mappings.

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -19,6 +19,20 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 		currentFlags.AppendMessage(messageTools)
 	}
 
+	if currentFlags.Pattern != "" && currentFlags.Model == "" {
+		if mapping, err2 := loadPatternModelMapping(); err2 == nil {
+			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
+				parts := strings.SplitN(modelSpec, "/", 2)
+				if len(parts) == 2 {
+					currentFlags.Vendor = parts[0]
+					currentFlags.Model = parts[1]
+				} else {
+					currentFlags.Model = modelSpec
+				}
+			}
+		}
+	}
+
 	var chatter *core.Chatter
 	if chatter, err = registry.GetChatter(currentFlags.Model, currentFlags.ModelContextLength,
 		currentFlags.Vendor, currentFlags.Strategy, currentFlags.Stream, currentFlags.DryRun); err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -14,6 +14,26 @@ import (
 
 // Cli Controls the cli. It takes in the flags and runs the appropriate functions
 func Cli(version string) (err error) {
+	if len(os.Args) > 1 && os.Args[1] == "pattern-model" {
+		switch {
+		case len(os.Args) == 5 && os.Args[2] == "set":
+			if err = setPatternModel(os.Args[3], os.Args[4]); err == nil {
+				fmt.Printf("pattern '%s' mapped to model '%s'\n", os.Args[3], os.Args[4])
+			}
+			return err
+		case len(os.Args) == 4 && os.Args[2] == "unset":
+			if err = unsetPatternModel(os.Args[3]); err == nil {
+				fmt.Printf("pattern '%s' mapping removed\n", os.Args[3])
+			}
+			return err
+		case len(os.Args) == 3 && os.Args[2] == "list":
+			err = listPatternModels()
+			return err
+		default:
+			return fmt.Errorf("usage: fabric pattern-model [set <pattern> <model>|unset <pattern>|list]")
+		}
+	}
+
 	var currentFlags *Flags
 	if currentFlags, err = Init(); err != nil {
 		return

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// getPatternModelFile returns the path to the pattern models mapping file
+func getPatternModelFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine user home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "fabric", "pattern_models.yaml"), nil
+}
+
+// loadPatternModelMapping loads the pattern->model mapping from disk. It returns
+// an empty map if the file does not exist.
+func loadPatternModelMapping() (map[string]string, error) {
+	path, err := getPatternModelFile()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	mapping := make(map[string]string)
+	if err := yaml.Unmarshal(data, &mapping); err != nil {
+		return nil, err
+	}
+	return mapping, nil
+}
+
+// setPatternModel updates the mapping file with the provided pattern and model.
+func setPatternModel(pattern, model string) error {
+	path, err := getPatternModelFile()
+	if err != nil {
+		return err
+	}
+	mapping, err := loadPatternModelMapping()
+	if err != nil {
+		return err
+	}
+	if mapping == nil {
+		mapping = make(map[string]string)
+	}
+	mapping[pattern] = model
+	data, err := yaml.Marshal(mapping)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// unsetPatternModel removes a pattern from the mapping file.
+func unsetPatternModel(pattern string) error {
+	path, err := getPatternModelFile()
+	if err != nil {
+		return err
+	}
+	mapping, err := loadPatternModelMapping()
+	if err != nil {
+		return err
+	}
+	delete(mapping, pattern)
+	if len(mapping) == 0 {
+		// Remove the mapping file if empty
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	data, err := yaml.Marshal(mapping)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// listPatternModels prints all pattern->model mappings to stdout.
+func listPatternModels() error {
+	mapping, err := loadPatternModelMapping()
+	if err != nil {
+		return err
+	}
+	if len(mapping) == 0 {
+		fmt.Println("no pattern model mappings found")
+		return nil
+	}
+	for pattern, model := range mapping {
+		fmt.Printf("%s: %s\n", pattern, model)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- allow setting default models per pattern via `~/.config/fabric/pattern_models.yaml`
- add helper commands to manage mappings: `set`, `unset`, and `list`
- document how to configure and manage pattern model mappings

## Testing
- `go test ./cmd/generate_changelog/internal/changelog -run TestFileProcessing_ErrorHandling -count=1 -v` *(fails: golang.org/x/net/context: /root/.local/share/mise/installs/go/1.24.3/pkg/tool/linux_amd64/vet: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ef28a5248325a04cbfc9b5872d7d