### PR TITLE
Use user config directory for pattern model mapping

### DIFF
--- a/docs/Pattern-Models.md
+++ b/docs/Pattern-Models.md
@@ -4,7 +4,7 @@ Fabric can automatically select a model for a pattern based on a user-defined ma
 
 ## Configuration
 
-Create `~/.config/fabric/pattern_models.yaml` with entries mapping pattern names to models:
+Create a `pattern_models.yaml` file in your user configuration directory (for example, `~/.config/fabric/pattern_models.yaml`) with entries mapping pattern names to models:
 
 ```yaml
 summarize: openai/gpt-4o-mini

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -10,11 +10,11 @@ import (
 
 // getPatternModelFile returns the path to the pattern models mapping file
 func getPatternModelFile() (string, error) {
-	home, err := os.UserHomeDir()
+	configDir, err := os.UserConfigDir()
 	if err != nil {
-		return "", fmt.Errorf("could not determine user home directory: %w", err)
+		return "", fmt.Errorf("could not determine user config directory: %w", err)
 	}
-	return filepath.Join(home, ".config", "fabric", "pattern_models.yaml"), nil
+	return filepath.Join(configDir, "fabric", "pattern_models.yaml"), nil
 }
 
 // loadPatternModelMapping loads the pattern->model mapping from disk. It returns

--- a/internal/cli/pattern_models_test.go
+++ b/internal/cli/pattern_models_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGetPatternModelFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	path, err := getPatternModelFile()
+	if err != nil {
+		t.Fatalf("getPatternModelFile returned error: %v", err)
+	}
+	expected := filepath.Join(tmp, "fabric", "pattern_models.yaml")
+	if path != expected {
+		t.Fatalf("expected %s, got %s", expected, path)
+	}
+}


### PR DESCRIPTION
## Summary
- Read pattern model mappings from `os.UserConfigDir()` instead of home directory
- Add test confirming config path resolution
- Document pattern model file location in user config directory

## Testing
- `go test ./...` *(hangs: ? github.com/danielmiessler/fabric/cmd/code_helper [no test files])*

------
https://chatgpt.com/codex/tasks/task_e_68a20bae4db08325b6a33d7a528a9968