### PR TITLE
Log pattern-model mapping load errors

### DIFF
--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -20,7 +20,10 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 	}
 
 	if currentFlags.Pattern != "" && currentFlags.Model == "" {
-		if mapping, err2 := loadPatternModelMapping(); err2 == nil {
+		mapping, err2 := loadPatternModelMapping()
+		if err2 != nil {
+			fmt.Fprintf(os.Stderr, "Failed to load pattern-model mapping: %v. Please check your mapping file.\n", err2)
+		} else {
 			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
 				parts := strings.SplitN(modelSpec, "/", 2)
 				if len(parts) == 2 {


### PR DESCRIPTION
## Summary
- Capture errors from `loadPatternModelMapping` in chat CLI.
- Inform users via stderr when mapping file fails to load.

## Testing
- `go test ./...` *(fails: TestFileProcessing_ErrorHandling)*

------
https://chatgpt.com/codex/tasks/task_e_68a20bb046b483258ace04783d888dd0