### PR TITLE
Normalize pattern model mapping lookups

### DIFF
--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -21,7 +21,7 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 
 	if currentFlags.Pattern != "" && currentFlags.Model == "" {
 		if mapping, err2 := loadPatternModelMapping(); err2 == nil {
-			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
+			if modelSpec, ok := mapping[strings.ToLower(currentFlags.Pattern)]; ok {
 				parts := strings.SplitN(modelSpec, "/", 2)
 				if len(parts) == 2 {
 					currentFlags.Vendor = parts[0]


### PR DESCRIPTION
## Summary
- Normalize pattern names to lowercase when setting and unsetting pattern-model mappings
- Add helpers to remove and list mappings with normalized keys
- Use lowercase patterns when resolving models during chat processing

## Testing
- `go test ./...` *(fails: process hung, manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a20bb2396883259081be8c9f1b1bc9